### PR TITLE
Security: Prevent leading zeroes in ipv4 octets

### DIFF
--- a/Lite.pm
+++ b/Lite.pm
@@ -181,7 +181,7 @@ sub _pack_ipv4 {
     my @nums = split /\./, shift(), -1;
     return unless @nums == 4;
     for (@nums) {
-        return unless /^\d{1,3}$/ and $_ <= 255;
+        return unless /^\d{1,3}$/ and !/^0\d{1,2}$/ and $_ <= 255;
     }
     pack("CC*", 0, @nums);
 }

--- a/t/base.t
+++ b/t/base.t
@@ -8,7 +8,7 @@
 use Test;
 use strict;
 $|++;
-BEGIN { plan tests => 39 };
+BEGIN { plan tests => 42 };
 use Net::CIDR::Lite;
 ok(1); # If we made it this far, we are ok.
 
@@ -133,3 +133,14 @@ ok(join(', ', @list_short_range), '10.0.0.1-2, 10.0.0.5');
 })->list_short_range;
 ok(join(', ', @list_short_range), '10.0.0.250-255, 10.0.1.0-20, 10.0.1.22, 10.0.2.250-255, 10.0.3.0-255, 10.0.4.0-255, 10.0.5.0-8');
 
+
+# Tests for vulnerability: https://blog.urth.org/2021/03/29/security-issues-in-perl-ip-address-distros/
+eval { Net::CIDR::Lite->new("010.0.0.0/8") };
+ok($@=~/Can't determine ip format/);
+
+my $err_octal = Net::CIDR::Lite->new;
+eval { $err_octal->add("010.0.0.0/8") };
+ok($@=~/Can't determine ip format/);
+
+eval { $err_octal->add("10.01.0.0/8") };
+ok($@=~/Can't determine ip format/);


### PR DESCRIPTION
This prevents prevents octal ipv4 addresses from being incorrectly
handled by not supporting leading zeroes.

010.0.0.1 was incorrectly treated as 10.0.0.1, rather than 8.0.0.1

More information is availabe here:
https://blog.urth.org/2021/03/29/security-issues-in-perl-ip-address-distros/